### PR TITLE
build script; OS X + brew does not put libgc.a on OS linker path; extend it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,7 @@
 name = "boehm_gc"
 version = "0.1.0"
 authors = ["swgillespie <sean.william.g@gmail.com>"]
+
+# We use the build script to discover what `-L` directive to
+# provide to the linker  to link to the pre-installed GC.
+build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+fn main() {
+    find_libgc();
+}
+
+fn find_libgc() {
+    'found: loop {
+        for d in &["/usr/local/lib"] {
+            if std::fs::metadata(format!("{}/libgc.a", d)).is_ok() {
+                println!("cargo:rustc-link-search=native={}", d);
+                break 'found;
+            }
+        }
+        panic!("no libgc found.");
+    }
+}


### PR DESCRIPTION
(You should not accept this PR; at least, not yet.)

I saw in the [README.md](../blob/master/README.md) that you say that it works for you with homebrew, but for me I needed to get cargo to add linker directives to the `rustc` invocation.

Do you have some other means for getting around this?

Anyway, this build script is not yet robust enough for inclusion. (It should probably emit nothing if the file is not found, but not panic at this point.  Ideally we would perhaps also invoke a compile of a dummy .c program that needs to link to libgc and make sure that doing so succeeds.)
